### PR TITLE
Revise README.adoc for upcoming preview release

### DIFF
--- a/.openshiftio/booster.yaml
+++ b/.openshiftio/booster.yaml
@@ -1,5 +1,5 @@
 name: Fuse Spring Boot Circuit Breaker Example
-description: A booster demonstrating how to set up the Circuit Breaker pattern with Fuse, camel and Spring Boot on OpenShift
+description: A booster demonstrating how to set up the Circuit Breaker pattern with Fuse, Camel and Spring Boot on OpenShift
 versions:
   - id: community
     name: 1.5.8.RELEASE (Community)

--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,7 @@ Wait until you can see that the pods for the `name-service` application and for 
 Click on the URL to access the greetings service application and follow the instructions on that page.
 
 
-== Running the booster on {launchURL}
+== Running the booster on OpenShift Online
 You can deploy the circuit breaker booster directly to OpenShift Online when you create the project at link:{launchURL}[].
 
 . Visit link:{launchURL}[].

--- a/README.adoc
+++ b/README.adoc
@@ -1,24 +1,29 @@
 = Circuit Breaker - Fuse Booster
 
-IMPORTANT: This runs best when deployed to OpenShift in order to use the circuit breaker functionality. For more details on using this booster with a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
+This booster can run in the following modes:
+
+* Standalone on your machine
+* Single-node OpenShift cluster
+* OpenShift Online at link:http://launch.openshift.io[]
+
+The most effective way to demonstrate the circuit breaker is to deploy and run the project on OpenShift.
+For more details on running this booster with a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
 IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
 
-IMPORTANT: This booster can run in 3 modes: standalone on your machine, on your Single-node OpenShift Cluster and directly deployed by link:http://launch.openshift.io[]
 
-IMPORTANT: As part of the process of creating this booster, launch.openshift.io set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
+== Running the booster standalone on your machine
+You can run this booster as a standalone project on your local machine:
 
-== Running the Booster standalone on your machine
-You can also run this booster as a standalone project directly:
-
-. Obtain the project and enter the project's directory
+. Download the project and extract the Zip file to your local filesystem.
 . Build the project:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
+$ cd PROJECT_DIR
 $ mvn clean package
 ----
-. In *2 separate console* run the 2 services:
+. In two separate shell prompts, run the two services as follows:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -32,35 +37,40 @@ and
 $ cd greetings-service
 $ mvn spring-boot:run
 ----
-. Follow the instructions visiting link:http://localhost:8080[]
+. Visit link:http://localhost:8080[] and follow the instructions on that page.
 
-== Running the Booster on a Single-node OpenShift Cluster
-If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can also deploy your booster there. A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+== Running the booster on a single-node OpenShift cluster
+If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your booster there.
+A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
 To deploy your booster to a running single-node OpenShift cluster:
 
-. Log in and create your project:
+. Download the project and extract the Zip file to your local filesystem.
+. Log in to your OpenShift cluster:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc login -u developer -p developer
-
+----
+. Create a new OpenShift project for the booster:
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
 $ oc new-project MY_PROJECT_NAME
 ----
-. Import base images in your newly created project (MY_PROJECT_NAME):
+. Build and deploy the project to the OpenShift cluster:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc import-image fis-java-openshift:2.0 --from=registry.access.redhat.com/jboss-fuse-6/fis-java-openshift:2.0 --confirm
-----
-. Unzip, build and deploy your booster:
-+
-[source,bash,options="nowrap",subs="attributes+"]
-----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift -Dfabric8.generator.fromMode=istag -Dfabric8.generator.from=MY_PROJECT_NAME/fis-java-openshift:2.0
+$ mvn clean fabric8:deploy -Popenshift
 ----
 
-== Running the Booster on launch.openshift.io
-You can obtain this project directly from link:http://launch.openshift.io[]:
- . Visit link:http://launch.openshift.io[]
- . Follow the instructions to download a zip of the project or directly deploy it on Openshift Online.
+
+== Running the booster on launch.openshift.io
+You can deploy the circuit breaker booster directly to OpenShift Online when you create the project at link:http://launch.openshift.io[].
+
+. Visit link:http://launch.openshift.io[].
+. At the *Deployment step*, select *Use OpenShift Online*.
+. Follow the on-screen instructions to create a new *Circuit Breaker* project using the *Fuse [Spring Boot]* runtime.
+
+NOTE: As part of the process of creating this booster, launch.openshift.io sets up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.

--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,26 @@
+:launchURL: https://developers.redhat.com/launch
+
 = Circuit Breaker - Fuse Booster
+
+== Overview
+The Fuse circuit breaker booster consists of two related services:
+
+* A _name service_, which returns a name to greet, and
+* A _greetings service_, which invokes the name service to get a name and then returns the string, `Hello, NAME`.
+
+In this demonstration, the Hystrix circuit breaker is inserted between the greetings service and the name service.
+If the name service becomes unavailable, the greetings service can fall back to an alternative behaviour and respond to the client immediately, instead of blocking while it waits for the name service to restart.
+
+== Deployment options
 
 This booster can run in the following modes:
 
 * Standalone on your machine
 * Single-node OpenShift cluster
-* OpenShift Online at link:http://launch.openshift.io[]
+* OpenShift Online at link:{launchURL}[]
 
 The most effective way to demonstrate the circuit breaker is to deploy and run the project on OpenShift.
-For more details on running this booster with a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
+For more details about running this booster on a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
 IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
 
@@ -15,7 +28,7 @@ IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greate
 == Running the booster standalone on your machine
 You can run this booster as a standalone project on your local machine:
 
-. Download the project and extract the Zip file to your local filesystem.
+. Download the project and extract the archive on your local filesystem.
 . Build the project:
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -23,7 +36,7 @@ You can run this booster as a standalone project on your local machine:
 $ cd PROJECT_DIR
 $ mvn clean package
 ----
-. In two separate shell prompts, run the two services as follows:
+. In two separate shell prompts, run the services as follows:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -43,34 +56,46 @@ $ mvn spring-boot:run
 If you have a single-node OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your booster there.
 A single-node OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
+IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
+Both of these products have suitable Fuse images pre-installed.
+
 To deploy your booster to a running single-node OpenShift cluster:
 
-. Download the project and extract the Zip file to your local filesystem.
+. Download the project and extract the archive on your local filesystem.
+
 . Log in to your OpenShift cluster:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc login -u developer -p developer
 ----
+
 . Create a new OpenShift project for the booster:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc new-project MY_PROJECT_NAME
 ----
+
 . Build and deploy the project to the OpenShift cluster:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean fabric8:deploy -Popenshift
+$ mvn clean -DskipTests fabric8:deploy -Popenshift
 ----
 
+. In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
+Wait until you can see that the pods for the `name-service` application and for the `greetings-service` application have both started up.
 
-== Running the booster on launch.openshift.io
-You can deploy the circuit breaker booster directly to OpenShift Online when you create the project at link:http://launch.openshift.io[].
+. Just above the entry for the `greetings-service` application on the `Overview` page, there is a URL of the form `http://greetings-service-test.OPENSHIFT_IP_ADDR.nip.io`.
+Click on the URL to access the greetings service application and follow the instructions on that page.
 
-. Visit link:http://launch.openshift.io[].
+
+== Running the booster on {launchURL}
+You can deploy the circuit breaker booster directly to OpenShift Online when you create the project at link:{launchURL}[].
+
+. Visit link:{launchURL}[].
 . At the *Deployment step*, select *Use OpenShift Online*.
-. Follow the on-screen instructions to create a new *Circuit Breaker* project using the *Fuse [Spring Boot]* runtime.
+. Follow the on-screen instructions to create a new *Circuit Breaker* project using the *Fuse* runtime.
 
-NOTE: As part of the process of creating this booster, launch.openshift.io sets up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
+NOTE: As part of the process of creating this booster, link:{launchURL}[] sets up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.


### PR DESCRIPTION
Here is the PR with suggested updates for the README file. I have two outstanding questions/suggestions:

- Would it be possible to tweak the POM so that tests do _not_ run by default? That would be a bit more user-friendly.
- Rather than give instructions on how to install the Fuse image to OpenShift, I think it would be better just to specify a version of OCP or CDK as a prerequisite (using versions that have the Fuse images pre-installed). This makes the instructions for running the demo on single-node OpenShift considerably simpler. I have taken this approach in the current draft. But if you need to change it back to the other approach, I can revise the draft.