### PR TITLE
#32 - fix (workaround?) for using correct version of tls on windows

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -132,7 +132,7 @@ if exist %WRAPPER_JAR% (
 ) else (
     echo Couldn't find %WRAPPER_JAR%, downloading it ...
 	echo Downloading from: %DOWNLOAD_URL%
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
     echo Finished downloading %WRAPPER_JAR%
 )
 @REM End of extension


### PR DESCRIPTION
by default in powsershell on Windows, it seems that the TLS version used
is 1.1 which now no more accepted on several sites. Version 1.2 needs to
be activated.

I guess that the mvnw.cmd is a file resued in and by a lot of projects. Where this mvnw.cmd file is coming? In order to know if they fixed it the same way upstream or not.