### PR TITLE
[ENTESB-16285] Wrong labels on fuse circuit breaker booster don't allow services and routes to work

### DIFF
--- a/greetings-service/.openshiftio/application.yaml
+++ b/greetings-service/.openshiftio/application.yaml
@@ -99,7 +99,7 @@ objects:
     labels:
       app: fuse-circuit-breaker-mission-greetings-service
       group: com.redhat.fuse.boosters
-      provider: fabric8
+      provider: jkube
   spec:
     output:
       to:
@@ -151,7 +151,7 @@ objects:
     labels:
       expose: "true"
       app: fuse-circuit-breaker-mission-greetings-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     name: greetings-service
   spec:
@@ -162,14 +162,14 @@ objects:
       targetPort: 8080
     selector:
       app: fuse-circuit-breaker-mission-greetings-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
       app: fuse-circuit-breaker-mission-greetings-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     name: greetings-service
   spec:
@@ -177,7 +177,7 @@ objects:
     revisionHistoryLimit: 2
     selector:
       app: fuse-circuit-breaker-mission-greetings-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     strategy:
       rollingParams:
@@ -187,7 +187,7 @@ objects:
       metadata:
         labels:
           app: fuse-circuit-breaker-mission-greetings-service
-          provider: fabric8
+          provider: jkube
           group: com.redhat.fuse.boosters
       spec:
         volumes:
@@ -246,7 +246,7 @@ objects:
   metadata:
     labels:
       app: fuse-circuit-breaker-mission-greetings-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     name: greetings-service
   spec:

--- a/greetings-service/src/main/jkube/deploymentconfig.yaml
+++ b/greetings-service/src/main/jkube/deploymentconfig.yaml
@@ -3,7 +3,7 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: greetings-service
-    provider: fabric8
+    provider: jkube
     group: ${project.groupId}
   name: greetings-service
 spec:
@@ -11,7 +11,7 @@ spec:
   revisionHistoryLimit: 2
   selector:
     app: greetings-service
-    provider: fabric8
+    provider: jkube
     group: ${project.groupId}
   strategy:
     rollingParams:
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         app: greetings-service
-        provider: fabric8
+        provider: jkube
         group: ${project.groupId}
     spec:
       volumes:

--- a/name-service/.openshiftio/application.yaml
+++ b/name-service/.openshiftio/application.yaml
@@ -69,7 +69,7 @@ objects:
     labels:
       app: fuse-circuit-breaker-mission-name-service
       group: com.redhat.fuse.boosters
-      provider: fabric8
+      provider: jkube
   spec:
     output:
       to:
@@ -121,7 +121,7 @@ objects:
     labels:
       expose: "true"
       app: fuse-circuit-breaker-mission-name-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     name: name-service
   spec:
@@ -132,14 +132,14 @@ objects:
       targetPort: 8080
     selector:
       app: fuse-circuit-breaker-mission-name-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
       app: fuse-circuit-breaker-mission-name-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     name: name-service
   spec:
@@ -147,7 +147,7 @@ objects:
     revisionHistoryLimit: 2
     selector:
       app: fuse-circuit-breaker-mission-name-service
-      provider: fabric8
+      provider: jkube
       group: com.redhat.fuse.boosters
     strategy:
       rollingParams:
@@ -157,7 +157,7 @@ objects:
       metadata:
         labels:
           app: fuse-circuit-breaker-mission-name-service
-          provider: fabric8
+          provider: jkube
           group: com.redhat.fuse.boosters
       spec:
         containers:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-16285
Upstream: https://github.com/jboss-fuse/fuse-springboot-circuit-breaker-booster/pull/62